### PR TITLE
GCC: Validate checksum

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,9 @@ RUN dpkg --add-architecture i386 \
   && curl -o /tmp/cmake_install.sh -sSL ${CMAKE_URL} \
   && chmod +x /tmp/cmake_install.sh \
   && /tmp/cmake_install.sh --skip-license --prefix=/usr/local \
-  && curl -o /tmp/gcc-arm-none-eabi.tar.bz2 -sSL ${GCC_ARM_URL} \
+  && curl -o ./gcc-arm-none-eabi.tar.bz2 -sSL ${GCC_ARM_URL} \
+  && curl -sSL $GCC_ARM_URL/+md5 | md5sum -c --status - \
+  && mv ./gcc-arm-none-eabi.tar.bz2 /tmp/gcc-arm-none-eabi.tar.bz2 \
   && tar xjvf /tmp/gcc-arm-none-eabi.tar.bz2 -C /usr/local \
   && mv /usr/local/gcc-arm-none-eabi-${GCC_ARM_VERSION}/ /usr/local/gcc-arm-embedded \
   && apt-get remove -qy bzip2 && apt-get clean && apt-get purge \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,9 @@ FROM particle/buildpack-base:0.3.8
 
 ARG GCC_ARM_URL
 ARG GCC_ARM_VERSION
-ARG CMAKE_URL
 
 RUN dpkg --add-architecture i386 \
   && apt-get update -q && apt-get install -qy make isomd5sum bzip2 vim-common libarchive-zip-perl libc6:i386 \
-  && curl -o /tmp/cmake_install.sh -sSL ${CMAKE_URL} \
-  && chmod +x /tmp/cmake_install.sh \
-  && /tmp/cmake_install.sh --skip-license --prefix=/usr/local \
   && curl -o ./gcc-arm-none-eabi.tar.bz2 -sSL ${GCC_ARM_URL} \
   && curl -sSL $GCC_ARM_URL/+md5 | md5sum -c --status - \
   && mv ./gcc-arm-none-eabi.tar.bz2 /tmp/gcc-arm-none-eabi.tar.bz2 \


### PR DESCRIPTION
Image now validates GCC checksum to ensure integrity
Image no longer downloads CMake
[ch26863]