### PR TITLE
Incorporate Workbench dependency installer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,75 @@
-FROM particle/buildpack-base:0.3.8
+ARG DEBIAN_FRONTEND=noninteractive
 
-ARG GCC_ARM_URL
-ARG GCC_ARM_CHECKSUM
-ARG GCC_ARM_VERSION
-ARG CMAKE_URL
+###############
+# Working image
+FROM node:8-slim as worker
+
+# Pull in temporary build environment variables
+ARG DEBIAN_FRONTEND
+ARG NPM_TOKEN
+ARG PARTICLE_DEVICEOS_VERSION
+ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
+
+# Copy GitHub credentials
+COPY ./.netrc /root/
+
+# Install build dependencies
+RUN ["bash", "-c", "\
+    apt-get update \
+ && apt-get install -y --no-install-recommends \
+      git \
+ && rm -rf /var/lib/apt/lists/* \
+"]
+
+# Setup Node environment
+RUN ["dash", "-c", "\
+    npm install -g npm@5 \
+"]
+
+# Clone Workbench source from GitHub
+RUN ["dash", "-c", "\
+    mkdir /particle-iot \
+ && cd /particle-iot \
+ && git clone https://github.com/particle-iot/workbench.git --recursive \
+ && chown --recursive node:node /particle-iot/workbench/ \
+"]
+
+# Install Workbench dependencies
+USER node
+WORKDIR /particle-iot/workbench/
+RUN ["dash", "-c", "\
+    npm config set //registry.npmjs.org/:_authToken=${NPM_TOKEN} \
+ && npm i --ignore-scripts \
+ && cd ./packages/particle-vscode-core/ \
+ && npm i --ignore-scripts \
+"]
+
+# Install toolchain dependencies
+RUN ["dash", "-c", "\
+    node /particle-iot/workbench/bin/installtoolchain.js ${PARTICLE_DEVICEOS_VERSION} \
+"]
+
+ENTRYPOINT ["sh"]
+
+#####################
+# Buildpack HAL image
+FROM particle/buildpack-base:0.3.8 as buildpack-hal
+
+COPY --from=worker /home/node/.particle/toolchains/gcc-arm/5.3.1 /usr/local/gcc-arm-embedded
 
 RUN dpkg --add-architecture i386 \
-  && apt-get update -q && apt-get install -qy \
-     bzip2 \
-     isomd5sum \
-     jq \
-     libarchive-zip-perl \
-     libc6:i386 \
-     make \
-     vim-common \
-     zip \
-  && curl -o /tmp/cmake_install.sh -sSL ${CMAKE_URL} \
-  && chmod +x /tmp/cmake_install.sh \
-  && /tmp/cmake_install.sh --skip-license --prefix=/usr/local \
-  && curl -o ./gcc-arm-none-eabi.tar.bz2 -sSL ${GCC_ARM_URL} \
-  && echo "${GCC_ARM_CHECKSUM} gcc-arm-none-eabi.tar.bz2" | md5sum -c --status - \
-  && mv ./gcc-arm-none-eabi.tar.bz2 /tmp/gcc-arm-none-eabi.tar.bz2 \
-  && tar xjvf /tmp/gcc-arm-none-eabi.tar.bz2 -C /usr/local \
-  && mv /usr/local/gcc-arm-none-eabi-${GCC_ARM_VERSION}/ /usr/local/gcc-arm-embedded \
-  && apt-get remove -qy bzip2 && apt-get clean && apt-get purge \
-  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/local/gcc-arm-embedded/share
+ && apt-get update -q && apt-get install -qy \
+      jq \
+# `libarchive-zip-perl` satisfies `crc32` dependency
+      libarchive-zip-perl \
+      libc6:i386 \
+      make \
+# `vim-common` satisfies `xxd` dependency
+      vim-common \
+      zip \
+ && apt-get clean \
+ && apt-get purge \
+ && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ENV PATH /usr/local/gcc-arm-embedded/bin:$PATH
 COPY bin /bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ FROM node:8-slim as worker
 # Pull in temporary build environment variables
 ARG DEBIAN_FRONTEND
 ARG NPM_TOKEN
-ARG PARTICLE_DEVICEOS_VERSION
+ARG PARTICLE_DEVICEOS_VERSION=1.4.0
 ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
 
 # Copy GitHub credentials


### PR DESCRIPTION
Currently, this creates the seam to allow us to incorporate the Workbench dependency installer, and uses it to install `gcc-arm` as a proof-of-concept.

Once this seam is established, then the tool can be refactored to pull the dependencies from the `device-os` repository.