### PR TITLE
Add ARM GCC 10.2

### DIFF
--- a/scripts/build-and-push
+++ b/scripts/build-and-push
@@ -1,10 +1,12 @@
 #!/bin/bash
 
-GCC_ARM_VERSIONS=( "5_3-2016q1" "9_2-2019q4" )
+GCC_ARM_VERSIONS=( "5_3-2016q1" "9_2-2019q4" "10_2-2020q4" )
 GCC_5_3_2016q1_CHECKSUM="5a261cac18c62d8b7e8c70beba2004bd"
 GCC_5_3_2016q1_URL="https://launchpad.net/gcc-arm-embedded/5.0/5-2016-q1-update/+download/gcc-arm-none-eabi-5_3-2016q1-20160330-linux.tar.bz2"
 GCC_9_2_2019q4_CHECKSUM="fe0029de4f4ec43cf7008944e34ff8cc"
 GCC_9_2_2019q4_URL="https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2019q4/gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2"
+GCC_10_2_2020q4_CHECKSUM="8312c4c91799885f222f663fc81f9a31"
+GCC_10_2_2020q4_URL="https://developer.arm.com/-/media/Files/downloads/gnu-rm/10-2020q4/gcc-arm-none-eabi-10-2020-q4-major-x86_64-linux.tar.bz2"
 
 CMAKE_VERSION="3.13.0"
 CMAKE_URL="https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.sh"

--- a/scripts/build-and-push
+++ b/scripts/build-and-push
@@ -11,7 +11,7 @@ GCC_10_2_2020q4_URL="https://developer.arm.com/-/media/Files/downloads/gnu-rm/10
 CMAKE_VERSION="3.13.0"
 CMAKE_URL="https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.sh"
 
-set -vx
+set -evx
 
 # Build image with GCC versions specified above
 for version in "${GCC_ARM_VERSIONS[@]}"


### PR DESCRIPTION
GCC 10.2 is required to enable LTO on Photon, see [device-os/#2288](https://github.com/particle-iot/device-os/pull/2288).