### PR TITLE
add 'manifest' variant with no GCC pre-installed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ ARG GCC_ARM_VERSION
 ARG CMAKE_URL
 
 RUN dpkg --add-architecture i386 \
+  && sed -i -e 's/http:\/\/archive/mirror:\/\/mirrors/' -e 's/\/ubuntu\//\/mirrors.txt/' /etc/apt/sources.list \
   && apt-get update -q && apt-get install -qy \
      bzip2 \
      isomd5sum \
@@ -15,15 +16,21 @@ RUN dpkg --add-architecture i386 \
      make \
      vim-common \
      zip \
+     wget \
+     parallel \
   && curl -o /tmp/cmake_install.sh -sSL ${CMAKE_URL} \
   && chmod +x /tmp/cmake_install.sh \
   && /tmp/cmake_install.sh --skip-license --prefix=/usr/local \
-  && curl -o ./gcc-arm-none-eabi.tar.bz2 -sSL ${GCC_ARM_URL} \
-  && echo "${GCC_ARM_CHECKSUM} gcc-arm-none-eabi.tar.bz2" | md5sum -c --status - \
-  && mv ./gcc-arm-none-eabi.tar.bz2 /tmp/gcc-arm-none-eabi.tar.bz2 \
-  && tar xjvf /tmp/gcc-arm-none-eabi.tar.bz2 -C /usr/local \
-  && mv /usr/local/gcc-arm-none-eabi-*/ /usr/local/gcc-arm-embedded \
-  && apt-get remove -qy bzip2 && apt-get clean && apt-get purge \
+  && { if [ "${GCC_ARM_VERSION}" != "manifest" ]; then \
+    curl -o ./gcc-arm-none-eabi.tar.bz2 -sSL ${GCC_ARM_URL} \
+    && echo "${GCC_ARM_CHECKSUM} gcc-arm-none-eabi.tar.bz2" | md5sum -c --status - \
+    && mv ./gcc-arm-none-eabi.tar.bz2 /tmp/gcc-arm-none-eabi.tar.bz2 \
+    && tar xjvf /tmp/gcc-arm-none-eabi.tar.bz2 -C /usr/local \
+    && mv /usr/local/gcc-arm-none-eabi-*/ /usr/local/gcc-arm-embedded; \
+  fi } \
+  && apt-get remove -qy bzip2 \
+  && apt-get clean \
+  && apt-get purge \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/local/gcc-arm-embedded/share
 
 ENV PATH /usr/local/gcc-arm-embedded/bin:$PATH

--- a/scripts/build-and-push
+++ b/scripts/build-and-push
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-GCC_ARM_VERSIONS=( "5_3-2016q1" "9_2-2019q4" "10_2-2020q4" )
+GCC_ARM_VERSIONS=( "manifest" "5_3-2016q1" "9_2-2019q4" "10_2-2020q4" )
 GCC_5_3_2016q1_CHECKSUM="5a261cac18c62d8b7e8c70beba2004bd"
 GCC_5_3_2016q1_URL="https://launchpad.net/gcc-arm-embedded/5.0/5-2016-q1-update/+download/gcc-arm-none-eabi-5_3-2016q1-20160330-linux.tar.bz2"
 GCC_9_2_2019q4_CHECKSUM="fe0029de4f4ec43cf7008944e34ff8cc"
@@ -21,6 +21,12 @@ do
 	GCC_ARM_URL="${!GCC_ARM_URL_VAR}"
 	GCC_ARM_CHECKSUM_VAR=GCC_$(echo $version | tr '-' '_')_CHECKSUM
 	GCC_ARM_CHECKSUM="${!GCC_ARM_CHECKSUM_VAR}"
+	DOCKER_TAG=$TRAVIS_TAG-gcc-arm-none-eabi-$GCC_ARM_VERSION
+	if [ "${GCC_ARM_VERSION}" == "manifest" ]; then
+		# No GCC will be downloaded
+		GCC_ARM_URL="none"
+		DOCKER_TAG="${TRAVIS_TAG}-manifest"
+	fi
 	echo "Building $GCC_ARM_VERSION from $GCC_ARM_URL ..."
 	docker build -t $DOCKER_IMAGE_NAME \
 --build-arg GCC_ARM_URL="$GCC_ARM_URL" \
@@ -30,8 +36,8 @@ do
 		.
 
 	if [ ! -z "$TRAVIS_TAG" ]; then
-		docker tag $DOCKER_IMAGE_NAME:latest $DOCKER_IMAGE_NAME:$TRAVIS_TAG-gcc-arm-none-eabi-$GCC_ARM_VERSION
-		docker push $DOCKER_IMAGE_NAME:$TRAVIS_TAG-gcc-arm-none-eabi-$GCC_ARM_VERSION
+		docker tag $DOCKER_IMAGE_NAME:latest $DOCKER_IMAGE_NAME:$DOCKER_TAG
+		docker push $DOCKER_IMAGE_NAME:$DOCKER_TAG
 	fi
 done
 # Push latest


### PR DESCRIPTION
### Description

Adds `manifest` variant for use with https://github.com/particle-iot/firmware-buildpack-builder/pull/22 with no GCC pre-installed.

Specified in Device OS sources like this: https://github.com/particle-iot/device-os/blob/test/v3.1.0-rc.1/.buildpackrc#L10

Completed build with this scheme on CI: https://g.codefresh.io/build/60cb9fce66c38f6d4363d78f

This PR also moves some of the commonly used dependencies into the buildpack-hal image, instead of installing them in `firmware-buildpack-builder` steps.

### Note

We should probably get rid of this intermediate image altogether, but for now this is the simplest change we can do.